### PR TITLE
Add a "Folders" Expression

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-Welp, trying to add folder support for now :P
+@info: <b>Project abandoned</b>

--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-@info: <b>Project abandoned</b>
+Welp, trying to add folder support for now :P

--- a/src/net/dzikoysk/wildskript/expressions/files/ExprFolders.java
+++ b/src/net/dzikoysk/wildskript/expressions/files/ExprFolders.java
@@ -1,0 +1,55 @@
+package net.dzikoysk.wildskript.expressions.files;
+
+import ch.njol.skript.lang.Expression;
+import ch.njol.skript.lang.SkriptParser;
+import ch.njol.skript.lang.util.SimpleExpression;
+import ch.njol.util.Kleenean;
+
+import java.io.File;
+import java.io.FilenameFilter;
+import java.util.regex.Matcher;
+
+import org.bukkit.event.Event;
+
+public class ExprFolders extends SimpleExpression<String>{
+    
+  private Expression<String> dir;
+
+  protected String[] get(Event event) {
+      String d = this.dir.getSingle(event);
+      if (d == null) return null;
+    
+      File f = new File(d.replaceAll("/", Matcher.quoteReplacement(File.separator)));
+      if(!f.exists()) f.mkdir();
+      String[] path = f.list(new FilenameFilter() {
+        @Override
+        public boolean accept(File current, String name) {
+          return new File(current, name).isDirectory();
+        }
+      });
+      if(path == null || path.length < 1) return null;
+      return path;
+  }
+
+  public boolean isSingle(){ 
+      return true;
+  }
+
+  public Class<? extends String> getReturnType() { 
+      return String.class;
+  }
+
+  public String toString(Event event, boolean b) {  
+      return this.getClass().toString(); 
+  }
+
+  @SuppressWarnings("unchecked")
+  public boolean init(Expression<?>[] expressions, int i, Kleenean kleenean, SkriptParser.ParseResult parseResult) {
+      this.dir = (Expression<String>) expressions[0];
+      return true;
+  }
+}
+
+
+
+

--- a/src/net/dzikoysk/wildskript/register/Expressions.java
+++ b/src/net/dzikoysk/wildskript/register/Expressions.java
@@ -22,6 +22,7 @@ import net.dzikoysk.wildskript.expressions.bukkit.ExprServerPort;
 import net.dzikoysk.wildskript.expressions.bukkit.ExprViewDistance;
 import net.dzikoysk.wildskript.expressions.files.ExprContent;
 import net.dzikoysk.wildskript.expressions.files.ExprFiles;
+import net.dzikoysk.wildskript.expressions.files.ExprFolders;
 import net.dzikoysk.wildskript.expressions.files.ExprYamlConfigurationSection;
 import net.dzikoysk.wildskript.expressions.files.ExprYamlSingleValue;
 import net.dzikoysk.wildskript.expressions.files.ExprYamlValueList;
@@ -139,7 +140,18 @@ public class Expressions {
 	
 		// Files
 		
-		
+
+		RegisterManager.registerExpression(new Element(Type.EXPRESSION)
+        .name("Folders")
+        .version("1.1")
+        .desc("Returns folders from folder into variables list ({list::*}).")
+        .example("set {scripts::*} to folders in " + '"' + "plugins/Skript/scripts" + '"')
+        .usage(new String[] {
+            "[all] folder[s] in %string%"
+        }), ExprFolders.class, String.class);
+
+
+
 		RegisterManager.registerExpression(new Element(Type.EXPRESSION)
 		.name("Content")
 		.version("1.5")


### PR DESCRIPTION
This was made by @overjt, and he gave me permission to add it to my
fork. It adds a "Folders" expression, which works like the "files" one,
except that, as the name siggests, it lists all folders inside the set
route. This can be very useful for detecting specific directories for
template worlds, for example.

Sorry for the extra commits. I changed the readme, but I undid it before making the pull request :P
